### PR TITLE
Add docstring for migrate_ckpt

### DIFF
--- a/shimmer/cli/ckpt_migration.py
+++ b/shimmer/cli/ckpt_migration.py
@@ -13,5 +13,15 @@ from shimmer.utils import migrate_model
     type=click.Path(exists=True, path_type=Path, file_okay=True, dir_okay=False),
 )
 def migrate_ckpt(paths: Sequence[Path]):
+    """
+    Script to migrate a list of checkpoints.
+    This can be called with:
+    ```sh
+    shimmer migrate-ckpt PATH_1 PATH_2 ... PATH_N
+    ```
+    where paths point to checkpoints.
+
+    Internally, this calls `shimmer.utils.migrate_model` for each of the given paths.
+    """
     for path in paths:
         migrate_model(path)


### PR DESCRIPTION
Missing docstring explaining how to use `shimmer migrate-ckpt`.