### PR TITLE
Add riggrep ignore to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,7 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# Ripgrep ignore
+.rgignore
+
 .ruff_cache/


### PR DESCRIPTION
.rgignore is used by ripgrep to ignore where to search files when greping some text.