### PR TITLE
Allow utility functions of GlobalWorkspaceBase to work on latent groups

### DIFF
--- a/shimmer/modules/gw_module.py
+++ b/shimmer/modules/gw_module.py
@@ -158,7 +158,7 @@ class GWModuleBase(nn.Module, ABC):
         ...
 
     @abstractmethod
-    def encode(self, x: LatentsDomainGroupT) -> LatentsDomainGroupT:
+    def encode(self, x: LatentsDomainGroupT) -> LatentsDomainGroupDT:
         """
         Encode the latent representation infos to the pre-fusion GW representation.
 
@@ -264,7 +264,7 @@ class GWModule(GWModuleBase):
             )
         )
 
-    def encode(self, x: LatentsDomainGroupT) -> LatentsDomainGroupT:
+    def encode(self, x: LatentsDomainGroupT) -> LatentsDomainGroupDT:
         """
         Encode the latent representation infos to the pre-fusion GW representation.
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -84,11 +84,13 @@ def test_training():
     assert unimodal_latents["v"].size() == (32, 128)
 
     selection_module = SingleDomainSelection()
-    workspace_latent = gw.encode_and_fuse(unimodal_latents, selection_module)
+    workspace_latent = gw.gw_mod.encode_and_fuse(unimodal_latents, selection_module)
 
     assert workspace_latent.size() == (32, 16)
 
-    reconstructed_unimodal_latents = gw.decode(workspace_latent, domains={"v", "a"})
+    reconstructed_unimodal_latents = gw.gw_mod.decode(
+        workspace_latent, domains={"v", "a"}
+    )
 
     assert reconstructed_unimodal_latents.keys() == {"v", "a"}
     assert reconstructed_unimodal_latents["v"].size() == (32, 128)


### PR DESCRIPTION
In `GlobalWorkspaceBase`, allow `encode`, `encode_and_fuse`, and `fuse` to work on latent groups rather than a single group like the
equivalent functions in `GWModule`.
