### PR TITLE
corrected order of valid and train data arguments in DomainDataModule

### DIFF
--- a/docs/shimmer_basics.md
+++ b/docs/shimmer_basics.md
@@ -334,8 +334,8 @@ from shimmer import RepeatedDataset
 class GWDataModule(LightningDataModule):
     def __init__(
         self,
-        val_datasets: dict[frozenset[str], DomainDataset],
         train_datasets: dict[frozenset[str], DomainDataset],
+        val_datasets: dict[frozenset[str], DomainDataset],
         batch_size: int,
     ) -> None:
         super().__init__()


### PR DESCRIPTION
here the order of validation and training where mixed up. This error goes all the way through to the trainer. I.e., training data and validation data get swapped!

Maybe adapt the code with keyword arguments so that the order does not matter?


PS:

If you want to double check the length of valid and train data used in the trainer, add in `class DomainDataModule`:

```
def get_train_length(self):
        return len(self.train_dataset)
def get_val_length(self):
        return len(self.val_dataset)
```


Then add before the unimodal module the following class:

```
from lightning.pytorch.callbacks import Callback


class DatasetLengthLogger(Callback):
    def on_train_end(self, trainer, pl_module):
        train_loader = trainer.datamodule.train_dataloader()
        val_loader = trainer.datamodule.val_dataloader()
        
        train_length = len(train_loader.dataset)
        val_length = len(val_loader.dataset)
        
        print(f"Training Data Length: {train_length}")
        print(f"Validation Data Length: {val_length}")

```

Finally, in def train module, before calling the trainer, add `dataset_length_logger = DatasetLengthLogger()`

And in trainer, add `dataset_length_logger` to the callbacks:

```
callbacks=[
            ModelCheckpoint(
                dirpath="checkpoints",
                filename=module_name,
                monitor="val_loss",
                mode="min",
                save_top_k=1,
            ),
            dataset_length_logger
        ],

```

Result:
Training Data Length 128
Validation Data Length 256