### PR TITLE
add step_limit to dynamicqueryattention

### DIFF
--- a/shimmer/modules/selection.py
+++ b/shimmer/modules/selection.py
@@ -237,7 +237,9 @@ class DynamicQueryAttention(SelectionBase):
             step_limit (`int`): Maximum number of steps to run the loop.
         """
         if step_limit > self.n_steps:
-            raise ValueError(f"Step limit cannot exceed the maximum n_steps ({self.n_steps}).")
+            raise ValueError(
+                f"Step limit cannot exceed the maximum n_steps ({self.n_steps})."
+            )
         self.step_limit = step_limit
 
     def fuse_weighted_encodings(


### PR DESCRIPTION
This just adds a way to have a given attention mechanism stop before it has completed all steps.
This makes sense because even though an attention mechanism is trained for n steps we may not always need to go the whole n steps.
I'm using this right now to train it for classification on the average of all steps. I think it should make it to shimmer since we'll probably use this functionality quite a lot.