### PR TITLE
revert: fix: max_size in DataDomain and ShimmerDataset (#180)

### DIFF
--- a/shimmer/data/domain.py
+++ b/shimmer/data/domain.py
@@ -23,7 +23,6 @@ class DataDomain(ABC, Generic[_T]):
         self,
         dataset_path: str | Path,
         split: str,
-        max_size: int | None = None,
         transform: Callable[[Any], _T] | None = None,
         additional_args: dict[str, Any] | None = None,
     ) -> None:


### PR DESCRIPTION
Revert the addition of max_size to `DataDomain`. Add warning if length of the different domains are different instead.
This prevents all DataDomain to have to implement max_size
