### PR TITLE
change step in GWLosses to solve bug when only contrastive loss

### DIFF
--- a/shimmer/modules/losses.py
+++ b/shimmer/modules/losses.py
@@ -763,7 +763,7 @@ class GWLosses(GWLossesBase):
             [
                 metrics[name]
                 for name, coef in self.loss_coefs.items()
-                if isinstance(coef, float) and coef > 0 and name != "contrastives"
+                if isinstance(coef, float) and name != "contrastives"
             ],
             dim=0,
         ).mean()


### PR DESCRIPTION
When training a GW with contrastive loss coef to one and all the other to zero an error was return because no loss were passing this condition